### PR TITLE
deploy: check for existence of PRIVATE_KEY env var

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -16,7 +16,7 @@ async function main() {
   let signer;
 
   if (process.env.SIGNER_PRIVATE_KEY) {
-    const wallet = new hre.ethers.Wallet(process.env.PRIVATE_KEY, hre.ethers.provider);
+    const wallet = new hre.ethers.Wallet(process.env.SIGNER_PRIVATE_KEY, hre.ethers.provider);
     signer = wallet;
   } else {
     // Use default Hardhat signer if PRIVATE_KEY not set


### PR DESCRIPTION
Adds a check for a private key env var being set s.t. one can deploy the contracts with any signer. If the env var is not set, old functionality is maintained of using the first default hardhat account. 

This PR helps unblock: https://github.com/primevprotocol/mev-commit/pull/78 