### PR TITLE
Resolves warnings, and adds neccesary updates for contract deployment

### DIFF
--- a/scripts/DeployScripts.s.sol
+++ b/scripts/DeployScripts.s.sol
@@ -24,8 +24,17 @@ contract DeployScript is Script {
         PreConfCommitmentStore preConfCommitmentStore = new PreConfCommitmentStore(address(providerRegistry), address(userRegistry), feeRecipient);
         console.log("PreConfCommitmentStore deployed to:", address(preConfCommitmentStore));
 
+        providerRegistry.setPreconfirmationsContract(address(preConfCommitmentStore));
+        console.log("ProviderRegistry updated with PreConfCommitmentStore address:", address(preConfCommitmentStore));
+
+        userRegistry.setPreconfirmationsContract(address(preConfCommitmentStore));
+        console.log("UserRegistry updated with PreConfCommitmentStore address:", address(preConfCommitmentStore));
+
         Oracle oracle = new Oracle(address(preConfCommitmentStore));
         console.log("Oracle deployed to:", address(oracle));
+
+        preConfCommitmentStore.updateOracle(address(oracle));
+        console.log("PreConfCommitmentStore updated with Oracle address:", address(oracle));
 
         vm.stopBroadcast();
     }


### PR DESCRIPTION
# There were some minor issues we were encountering when testing the e2e, this updates the deployment script to avoid those issues.

- The issues arose because we initially didn't use the private key that deployed the oracle to add a builder grafiti name to builder address in our protocol. You  can see the failure on the block explorer [here](http://34.215.163.180:11227/transactions/0x371752150664e87e578ddcf7209657e854da3f2a4404ed1e73998f5484a94cff)- The second issue was that the pre-conf contract didn't have the Oracle set in the deployment. You can see the issue [here](http://34.215.163.180:11227/transactions/0xc5ba3edba18ead4c88a77531a94f29d6f54fb5bcd5e91ab408944d71e59368da).
- re-deployed Oracle here: 0xf5B6dC9E8885D512E38f5e656093880827a3Cbd5
- Next the registry didn’t have the correct pre-cons contact set. You can see this [here](http://34.215.163.180:11227/transactions/0xbf125254294e80af1f78312d0a2bf5981bd30e4eed1c1d73385ad30ca7fe3ab6).

Once we updated these, we found success! 
Check out the successful reward distribution [here](http://34.215.163.180:11227/transactions/0xd9663804b3c8b222ab158a3865a41e72334daaddcf107472ccf81b7b7c27f5b2/events). Immortalized as the first pre-conf! 🥳 🎉 


You can see here that 2 wei was rewarded to the provider:
```bash
$ cast call --rpc-url http://34.215.163.180:8545 0x17855D7AB9B84cF2eddb8a7Db2df825c54a492aD  "getProviderAmount(address)" 0x15766e4fC283Bb52C5c470648AeA2b5Ad133410a
> 0x0000000000000000000000000000000000000000000000000000000000000002
```